### PR TITLE
Version 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.bin
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Disconnect from the cloud, publish 5 events of 64 bytes each, then go back onlin
 
 ## Version History
 
+### 0.2.0 (2020-11-06)
+
+- Fixed a bug in all file-based implementations (Spiffs, SdFat) where events were not published after a reboot.
+- Added a new test suite function (7) to disconnect, post events to the queue, then reboot.
+- Added support for storing events on the POSIX file system on Gen 3 devices (Argon, Boron, Tracker SoM) in 2.0.0-rc.3 and later.
+
 ### 0.1.3 (2019-11-21)
 
 - Added getNumEvent() method so you can know if the queue is empty or not

--- a/examples/3-test-suite/3-test-suite-PublishQueueAsyncRK.cpp
+++ b/examples/3-test-suite/3-test-suite-PublishQueueAsyncRK.cpp
@@ -16,7 +16,8 @@ enum {
 	TEST_PUBLISH_OFFLINE, // 3 go offline, publish some events, then go back online, number is param0, optional size in param2
 	TEST_COUNTER_WITH_ACK, // 4 publish, period milliseconds is param0 but use WITH_ACK mode
 	TEST_PAUSE_PUBLISING, // 5 pause publishing
-	TEST_RESUME_PUBLISING // 6 resume publishing
+	TEST_RESUME_PUBLISING, // 6 resume publishing
+	TEST_PUBLISH_OFFLINE_RESET // 7 go offline, publish some events, reset device, number is param0, optional size in param2
 };
 
 // Example:
@@ -72,9 +73,7 @@ void loop() {
 		}
 	}
 	else
-	if (testNum == TEST_PUBLISH_OFFLINE) {
-		testNum = TEST_IDLE;
-
+	if (testNum == TEST_PUBLISH_OFFLINE || testNum == TEST_PUBLISH_OFFLINE_RESET) {
 		int count = intParam[0];
 		int size = intParam[1];
 
@@ -91,6 +90,14 @@ void loop() {
 		}
 
 		Log.info("after publishing numEvents=%d", publishQueue.getNumEvents());
+
+		if (testNum == TEST_PUBLISH_OFFLINE_RESET) {
+			Log.info("resetting device...");			
+			delay(100);
+			System.reset();
+		}
+
+		testNum = TEST_IDLE;
 
 		Log.info("Going to Particle.connect()...");
 		Particle.connect();

--- a/examples/4-test-suite-posix/4-test-suite-posix-PublishQueueAsyncRK.cpp
+++ b/examples/4-test-suite-posix/4-test-suite-posix-PublishQueueAsyncRK.cpp
@@ -1,19 +1,14 @@
 #include "Particle.h"
 
-// This must be included before PublishQueueAsyncRK.h to add in SdFat support
-#include "SdFat.h"
-
 #include "PublishQueueAsyncRK.h"
 
 SYSTEM_THREAD(ENABLED);
 
-SerialLogHandler logHandler;
+SerialLogHandler logHandler(LOG_LEVEL_INFO, { // Logging level for non-application messages
+	{ "app.pubq", LOG_LEVEL_TRACE }
+});
 
-const int SD_CHIP_SELECT = A2;
-
-SdFat sdCard;
-
-PublishQueueAsyncSdFat publishQueue(sdCard, "events.dat");
+PublishQueueAsyncPOSIX publishQueue("events");
 
 enum {
 	TEST_IDLE = 0, // Don't do anything
@@ -45,20 +40,13 @@ void publishCounter(bool withAck);
 void publishPaddedCounter(int size);
 
 void setup() {
-	Serial.begin();
-
-	Particle.function("test", testHandler);
-
 	// For testing purposes, wait 10 seconds before continuing to allow serial to connect
 	// before doing publishQueue.setup() so the debug log messages can be read.
 	waitFor(Serial.isConnected, 10000);
-
-	if (sdCard.begin(SD_CHIP_SELECT, SPI_FULL_SPEED)) {
-		publishQueue.setup();
-	}
-	else {
-		Log.info("failed to initialize sd card");
-	}
+    delay(1000);
+    
+	Particle.function("test", testHandler);
+	publishQueue.setup();
 }
 
 void loop() {
@@ -193,5 +181,3 @@ int testHandler(String cmd) {
 	free(mutableCopy);
 	return 0;
 }
-
-

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 # Fill in information about your library then remove # from the start of lines
 # https://docs.particle.io/guide/tools-and-features/libraries/#library-properties-fields
 name=PublishQueueAsyncRK
-version=0.1.3
+version=0.2.0
 author=rickkas7@rickkas7.com
 license=MIT
 sentence=Asynchronous publishing code for the Particle Electron

--- a/more-examples/FRAMExample/src/FRAMExample.cpp
+++ b/more-examples/FRAMExample/src/FRAMExample.cpp
@@ -20,7 +20,8 @@ enum {
 	TEST_PUBLISH_OFFLINE, // 3 go offline, publish some events, then go back online, number is param0, optional size in param2
 	TEST_COUNTER_WITH_ACK, // 4 publish, period milliseconds is param0 but use WITH_ACK mode
 	TEST_PAUSE_PUBLISING, // 5 pause publishing
-	TEST_RESUME_PUBLISING // 6 resume publishing
+	TEST_RESUME_PUBLISING, // 6 resume publishing
+	TEST_PUBLISH_OFFLINE_RESET // 7 go offline, publish some events, reset device, number is param0, optional size in param2
 };
 
 // Example:
@@ -84,9 +85,7 @@ void loop() {
 		}
 	}
 	else
-	if (testNum == TEST_PUBLISH_OFFLINE) {
-		testNum = TEST_IDLE;
-
+	if (testNum == TEST_PUBLISH_OFFLINE || testNum == TEST_PUBLISH_OFFLINE_RESET) {
 		int count = intParam[0];
 		int size = intParam[1];
 
@@ -103,6 +102,14 @@ void loop() {
 		}
 
 		Log.info("after publishing numEvents=%d", publishQueue.getNumEvents());
+
+		if (testNum == TEST_PUBLISH_OFFLINE_RESET) {
+			Log.info("resetting device...");			
+			delay(100);
+			System.reset();
+		}
+
+		testNum = TEST_IDLE;
 
 		Log.info("Going to Particle.connect()...");
 		Particle.connect();

--- a/more-examples/SpiffsExample/.gitignore
+++ b/more-examples/SpiffsExample/.gitignore
@@ -1,0 +1,4 @@
+lib
+target
+*.bin
+.vscode

--- a/more-examples/SpiffsExample/project.properties
+++ b/more-examples/SpiffsExample/project.properties
@@ -1,2 +1,3 @@
-dependencies.SpiffsParticleRK=0.0.6
-dependencies.SpiFlashRK=0.0.5
+name=SpiffsExample
+dependencies.SpiffsParticleRK=0.0.8
+dependencies.SpiFlashRK=0.0.9

--- a/more-examples/SpiffsExample/src/SpiffsExample.cpp
+++ b/more-examples/SpiffsExample/src/SpiffsExample.cpp
@@ -8,14 +8,13 @@
 SYSTEM_THREAD(ENABLED);
 
 SerialLogHandler logHandler(LOG_LEVEL_INFO, { // Logging level for non-application messages
-    { "app.spiffs", LOG_LEVEL_ERROR } // Logging level for SPIFFS messages
+    { "app.spiffs", LOG_LEVEL_ERROR }, // Logging level for SPIFFS messages
+	{ "app.pubq", LOG_LEVEL_TRACE }
 });
 
-// SpiFlashWinbond spiFlash(SPI, A4);	// Winbond flash on SPI (A pins on Gen 2, regular SCK/MOSI/MISO on Gen 3)
-
+SpiFlashWinbond spiFlash(SPI, A2);	// Winbond flash on SPI (A pins on Gen 2, regular SCK/MOSI/MISO on Gen 3)
 // SpiFlashISSI spiFlash(SPI, A2); 		// ISSI flash on SPI (A pins)
-
-SpiFlashP1 spiFlash;					// P1 external flash inside the P1 module
+// SpiFlashP1 spiFlash;					// P1 external flash inside the P1 module
 
 
 SpiffsParticle fs(spiFlash);
@@ -29,7 +28,8 @@ enum {
 	TEST_PUBLISH_OFFLINE, // 3 go offline, publish some events, then go back online, number is param0, optional size in param2
 	TEST_COUNTER_WITH_ACK, // 4 publish, period milliseconds is param0 but use WITH_ACK mode
 	TEST_PAUSE_PUBLISING, // 5 pause publishing
-	TEST_RESUME_PUBLISING // 6 resume publishing
+	TEST_RESUME_PUBLISING, // 6 resume publishing
+	TEST_PUBLISH_OFFLINE_RESET // 7 go offline, publish some events, reset device, number is param0, optional size in param2
 };
 
 // Example:
@@ -100,9 +100,7 @@ void loop() {
 		}
 	}
 	else
-	if (testNum == TEST_PUBLISH_OFFLINE) {
-		testNum = TEST_IDLE;
-
+	if (testNum == TEST_PUBLISH_OFFLINE || testNum == TEST_PUBLISH_OFFLINE_RESET) {
 		int count = intParam[0];
 		int size = intParam[1];
 
@@ -119,6 +117,14 @@ void loop() {
 		}
 
 		Log.info("after publishing numEvents=%d", publishQueue.getNumEvents());
+
+		if (testNum == TEST_PUBLISH_OFFLINE_RESET) {
+			Log.info("resetting device...");			
+			delay(100);
+			System.reset();
+		}
+
+		testNum = TEST_IDLE;
 
 		Log.info("Going to Particle.connect()...");
 		Particle.connect();


### PR DESCRIPTION
- Fixed a bug in all file-based implementations (Spiffs, SdFat) where events were not published after a reboot.
- Added a new test suite function (7) to disconnect, post events to the queue, then reboot.
- Added support for storing events on the POSIX file system on Gen 3 devices (Argon, Boron, Tracker SoM) in 2.0.0-rc.3 and later.
